### PR TITLE
chore: use dotenv instead of eval for windows support

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,2 @@
+API=api_url
+API_SECRET=api_secret

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ prototypes
 tmp
 
 .env*
+!.env*.example
 
 .vscode

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,7 @@
+require('dotenv').config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+
 const {API, API_SECRET} = process.env
 if (!API) {
   throw new Error('We need an API environment variable !')

--- a/package.json
+++ b/package.json
@@ -6,12 +6,9 @@
   "license": "Unlicense",
   "scripts": {
     "build": "gatsby build",
-    "build:prod": "eval $(cat .env.prod) gatsby build",
     "clean": "rimraf public .cache node_modules/.cache",
     "serve": "http-server ./public -p 8000 -P http://localhost:8000",
-    "start": "npm run start:dev",
-    "start:dev": "eval $(cat .env.dev) gatsby develop",
-    "start:prod": "eval $(cat .env.prod) gatsby develop",
+    "start": "gatsby develop",
     "test": "jest",
     "type-check": "tsc --noEmit"
   },
@@ -29,6 +26,7 @@
     "caniuse-lite": "^1.0.30001040",
     "classnames": "^2.2.6",
     "core-js": "^2.6.9",
+    "dotenv": "^8.2.0",
     "gatsby": "^2.20.15",
     "gatsby-image": "^2.3.2",
     "gatsby-plugin-accessibilityjs": "^1.0.3",


### PR DESCRIPTION
# بسم الله الرحمن الرحيم

## What's new in this PR?
chore: use dotenv instead of eval for windows support

## Note 

After this PR you should rename your env file to `.env.development`


لله الحمد والمنة